### PR TITLE
Enable printing mass in LAMMPS data file

### DIFF
--- a/src_clean/axpy.cu
+++ b/src_clean/axpy.cu
@@ -55,7 +55,7 @@ inline void GenerateRestartMovies(Components& SystemComponents, Simulations& Sim
   create_Restart_file(0, SystemComponents.HostSystem, SystemComponents, SystemComponents.FF, HostBox, PseudoAtom.Name, systemIdx);
   Write_All_Adsorbate_data(0, SystemComponents.HostSystem, SystemComponents, SystemComponents.FF, HostBox, PseudoAtom.Name, systemIdx);
   //Only generate LAMMPS data movie for production phase
-  if(SimulationMode == PRODUCTION)  create_movie_file(SystemComponents.HostSystem, SystemComponents, HostBox, PseudoAtom.Name, systemIdx);
+  if(SimulationMode == PRODUCTION)  create_movie_file(SystemComponents.HostSystem, SystemComponents, HostBox, PseudoAtom.Name, PseudoAtom.mass, systemIdx);
 }
 
 ///////////////////////////////////////////////////////////


### PR DESCRIPTION
This update enables:

1. Printing atomic mass in the LAMMPS data file

2. More accurate conversion of epsilon parameters from internal units in [10 J/mol] to [kcal/mol] for use in LAMMPS with "real" units.