### PR TITLE
Better total energy report & small bug fix for NU-2000 Example

### DIFF
--- a/src_clean/data_struct.h
+++ b/src_clean/data_struct.h
@@ -959,7 +959,8 @@ struct Components
   }
   MoveEnergy CreateMoldeltaE;
   MoveEnergy deltaE;
-  double  FrameworkEwald=0.0;
+  double  FrameworkEwald=0.0;        //calculated at every stage (initial, create molecule, final)
+  double  InitialFrameworkEwald=0.0; //calculated ONLY at initial stage, then stored//
   bool    HasTailCorrection = false;                // An overall flag for tail correction
   bool    ReadRestart = false;                      // Whether to use restart files //Zhao's note: this can be either RASPA-2-type Restart file or LAMMPS data file //
   int     RestartInputFileType = RASPA_RESTART;          // can choose from: RASPA_RESTART or LAMMPS_DATA (see enum at the beginning of this file)

--- a/src_clean/ewald_preparation.h
+++ b/src_clean/ewald_preparation.h
@@ -226,7 +226,6 @@ void Ewald_Total(Boxsize& Box, Atoms*& Host_System, ForceField& FF, Components& 
     fprintf(SystemComponents.OUTPUT, "Component: %zu, Intra-Molecular ExclusionE: %.5f (%.5f kJ/mol)\n", l, exclusionE, exclusionE*1.2027242847);
   }
   SystemComponents.FrameworkEwald = E.HHEwaldE;
-
   /*
   if(ExcludeHostGuestEwald)
     E -= E.HHEwaldE;

--- a/src_clean/main.cpp
+++ b/src_clean/main.cpp
@@ -17,7 +17,7 @@
 #include "fxn_main.h"
 
 #include <unistd.h>
-// // // // // // // // // // // // // // #include <limits.h>
+// // // // // // // // // // // // // // // // #include <limits.h>
 
 void printMemoryUsage() 
 {

--- a/src_clean/read_data.cpp
+++ b/src_clean/read_data.cpp
@@ -503,7 +503,7 @@ void read_FFParams_from_input(Input_Container& Input)
         Input.VDWRealBias = false;
       }
     }
-    if (str.find("Component", 0) != std::string::npos) //When it reads component, skip//
+    if (str.find("Component ", 0) != std::string::npos) //When it reads component, skip//
       break;
   }
   //read FF array

--- a/src_clean/write_data.h
+++ b/src_clean/write_data.h
@@ -208,7 +208,7 @@ static inline void copyFile(const std::string& sourcePath, const std::string& de
 
   if (!source.is_open() || !destination.is_open()) 
   {
-    std::cerr << "Error opening " << sourcePath << " or " << destinationPath << std::endl;
+    std::cerr << "Cannot Open " << sourcePath << " or " << destinationPath << std::endl;
     return; // false;
   }
 


### PR DESCRIPTION
Better total energy report & small bug fix for NU-2000 Example
1. total energy report is better 1.1 Before, total energy reported in "INITIAL/CREATE MOLECULE/FINAL STAGE" still includes host-host fourier part energy of Ewald summation 1.2 This is set to zero in RASPA-2 (or later code), sort of "background energy", since a lot of times, framework is fixed (rigid). Framework acts like a field. 1.3 Now, initial Fourier energy for framework components are stored, so Initial Fourier of Ewald for host-host STARTS at ZERO. 1.4 the initial host-host fourier is now added as a subsection when reporting the STAGE energies, giving user all the information.
2. small fix for NU-2000 2.1 due to a small error when reading the input file, previous NU-2000 example is not using charges when specified Ewald 2.2 Fixed