### PR TITLE
Further Optimization and Speedup

### DIFF
--- a/NVC_COMPILE
+++ b/NVC_COMPILE
@@ -8,16 +8,16 @@ LINKFLAG="-L/opt/nvidia/hpc_sdk/Linux_x86_64/22.5/cuda/lib64 -L/usr/lib64/ -L/op
 
 NVCFLAG="-O3 -std=c++20 -target=gpu -Minline -fopenmp -cuda -stdpar=multicore"
 
-$CXX $NVCFLAG $LINKFLAG -c axpy.cu
+$CXX $NVCFLAG $LINKFLAG -c axpy.cu ; echo "Finished axpy.cu"
 
-$CXX $NVCFLAG $LINKFLAG -c main.cpp
+$CXX $NVCFLAG $LINKFLAG -c main.cpp ; echo "Finished main.cpp"
 
-$CXX $NVCFLAG $LINKFLAG -c read_data.cpp
+$CXX $NVCFLAG $LINKFLAG -c read_data.cpp ; echo "Finished read_data.cpp"
 
-$CXX $NVCFLAG $LINKFLAG -c data_struct.cpp
+$CXX $NVCFLAG $LINKFLAG -c data_struct.cpp ; echo "Finished data_struct.cpp"
 
-$CXX $NVCFLAG $LINKFLAG -c VDW_Coulomb.cu
+$CXX $NVCFLAG $LINKFLAG -c VDW_Coulomb.cu ; echo "Finished VDW_Coulomb.cu"
 
-$CXX $NVCFLAG $LINKFLAG main.o read_data.o axpy.o data_struct.o VDW_Coulomb.o -o nvc_main.x
+$CXX $NVCFLAG $LINKFLAG main.o read_data.o axpy.o data_struct.o VDW_Coulomb.o -o nvc_main.x ; echo "Finished Linking"
 
 rm *.o


### PR DESCRIPTION
1. Further Optimized Ewald Summation Initialization, speed is increased by 10-20% for simulations
   * Examples:
     * CO2-MFI: 9.7 → 8.3 seconds
     * Bae-Mixture: 108.8 → 97.2 seconds
     * NU-2000: 17.20 → 7.97 seconds
     * NPTMC: 223.73 → 180.81 seconds
     * NVT-Gibbs (100 + 100 cycles): 35.3 → 31.82 seconds
2. Small update for Compilation file: NVC_COMPILE
   * added echoes