### PR TITLE
Support Allegro models trained on total configuration energies

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,5 +7,8 @@ src_clean/nvc_main.x
 __pycache__/
 *.pyc
 
+# Generated source trees
+/patch_*/
+
 # Claude Code
 .claude/

--- a/Examples/CO2_MgMOF74_Allegro/README.md
+++ b/Examples/CO2_MgMOF74_Allegro/README.md
@@ -1,1 +1,15 @@
 This folder contains example simulation input files for modeling CO2 adsorption in Mg-MOF-74 using machine learning potential (Allegro model). Details about Allegro model are available in `ML_potential_details` folder.
+
+By default, gRASPA assumes that the model predicts a host--guest interaction
+energy. Models trained to predict the total energy of the combined structure
+must instead add the following keyword to `simulation.input`:
+
+```
+DNNModelEnergyMode total
+```
+
+In `total` mode, gRASPA evaluates the rigid empty framework and isolated rigid
+adsorbate once during initialization and subtracts those reference energies
+from every combined prediction. The default is
+`DNNModelEnergyMode interaction`, which preserves the behavior expected by
+this CO2 example.

--- a/Examples/test_allegro_energy_dtype.py
+++ b/Examples/test_allegro_energy_dtype.py
@@ -1,0 +1,22 @@
+"""Regression checks for Allegro atomic-energy tensor handling."""
+
+from pathlib import Path
+
+
+REPO = Path(__file__).resolve().parents[1]
+ALLEGRO_HEADER = REPO / 'src_clean' / 'torch_allegro.h'
+
+
+def test_atomic_energies_are_accumulated_as_float64():
+    """Accept float32 or float64 model output without losing precision."""
+    source = ALLEGRO_HEADER.read_text()
+    tensor_start = source.index(
+        'torch::Tensor atomic_energy_tensor ='
+    )
+    tensor_end = source.index('nstep ++;', tensor_start)
+    tensor_block = source[tensor_start:tensor_end]
+
+    assert '.to(torch::kFloat64)' in tensor_block
+    assert 'accessor<double, 2>()' in tensor_block
+    assert 'double nAtomSum = 0.0;' in tensor_block
+    assert 'accessor<float, 2>()' not in tensor_block

--- a/libtorch-patch/Allegro/PATCH_ALLEGRO_DNN_HostGuest_Energy_Functions.h.txt
+++ b/libtorch-patch/Allegro/PATCH_ALLEGRO_DNN_HostGuest_Energy_Functions.h.txt
@@ -1,13 +1,14 @@
 PATCH_ALLEGRO_CONSIDER_DNN_ATOMS
 void Check_DNNAtom_and_copy_pos_to_UCAtoms(double3* temp_pos, Atoms& UCAtoms, bool* ConsiderThisAdsorbateAtom, size_t Molsize)
 {
-  size_t update_i = 0;
-  for(size_t i = 0; i < Molsize; i++)
-  {
-    if(ConsiderThisAdsorbateAtom[i])
-      UCAtoms.pos[update_i] = temp_pos[i];
-    update_i ++;
-  }
+  const size_t copied = CopySelectedDNNAtoms(
+      temp_pos,
+      UCAtoms.pos,
+      ConsiderThisAdsorbateAtom,
+      Molsize);
+  if(copied != UCAtoms.size)
+    throw std::runtime_error(
+        "Number of selected DNN adsorbate atoms does not match Allegro input");
 }
 
 PATCH_ALLEGRO_INSERTION

--- a/libtorch-patch/Allegro/PATCH_ALLEGRO_DNN_HostGuest_Energy_Functions.h.txt
+++ b/libtorch-patch/Allegro/PATCH_ALLEGRO_DNN_HostGuest_Energy_Functions.h.txt
@@ -5,7 +5,8 @@ void Check_DNNAtom_and_copy_pos_to_UCAtoms(double3* temp_pos, Atoms& UCAtoms, bo
       temp_pos,
       UCAtoms.pos,
       ConsiderThisAdsorbateAtom,
-      Molsize);
+      Molsize,
+      UCAtoms.size);
   if(copied != UCAtoms.size)
     throw std::runtime_error(
         "Number of selected DNN adsorbate atoms does not match Allegro input");

--- a/libtorch-patch/Allegro/PATCH_ALLEGRO_data_struct.h.txt
+++ b/libtorch-patch/Allegro/PATCH_ALLEGRO_data_struct.h.txt
@@ -1,5 +1,6 @@
 PATCH_ALLEGRO_DATA_STRUCT_H
 #include <torch/script.h> // One-stop header.
+#include "dnn_energy_reference.h"
 
 PATCH_ALLEGRO_VARIABLES
   //Allegro Model//

--- a/libtorch-patch/Allegro/PATCH_ALLEGRO_main.cpp.txt
+++ b/libtorch-patch/Allegro/PATCH_ALLEGRO_main.cpp.txt
@@ -9,6 +9,8 @@ PATCH_ALLEGRO_MAIN_PREP
       {
         printf("Setting up Allegro model\n");
         Vars.SystemComponents[a].DNN.ReadModel(Vars.SystemComponents[a].ModelName[0]);
+        Vars.SystemComponents[a].DNN.ModelUsesTotalEnergy =
+            Comp_for_DNN_Model[a].DNN.ModelUsesTotalEnergy;
         printf("DONE Reading the model, model name %s\n", Vars.SystemComponents[a].ModelName[0].c_str());
         Vars.SystemComponents[a].DNN.Match_Element_PseudoAtom_with_model(Vars.SystemComponents[a].PseudoAtoms);
 

--- a/libtorch-patch/Allegro/PATCH_ALLEGRO_read_data.cpp.txt
+++ b/libtorch-patch/Allegro/PATCH_ALLEGRO_read_data.cpp.txt
@@ -22,7 +22,10 @@ void ReadAllegroModelParameters(Components& SystemComponents)
     }
     if (str.find("DNNModelEnergyMode", 0) != std::string::npos)
     {
-      termsScannedLined = split(str, ' ');
+      Split_Tab_Space(termsScannedLined, str);
+      if(termsScannedLined.size() < 2)
+        throw std::runtime_error(
+            "DNNModelEnergyMode requires total or interaction");
       if(caseInSensStringCompare(termsScannedLined[1], "total"))
         SystemComponents.DNN.ModelUsesTotalEnergy = true;
       else if(!caseInSensStringCompare(termsScannedLined[1], "interaction"))

--- a/libtorch-patch/Allegro/PATCH_ALLEGRO_read_data.cpp.txt
+++ b/libtorch-patch/Allegro/PATCH_ALLEGRO_read_data.cpp.txt
@@ -20,9 +20,21 @@ void ReadAllegroModelParameters(Components& SystemComponents)
       SystemComponents.DNNDrift = std::stod(termsScannedLined[1]);
       found_drift = true;
     }
+    if (str.find("DNNModelEnergyMode", 0) != std::string::npos)
+    {
+      termsScannedLined = split(str, ' ');
+      if(caseInSensStringCompare(termsScannedLined[1], "total"))
+        SystemComponents.DNN.ModelUsesTotalEnergy = true;
+      else if(!caseInSensStringCompare(termsScannedLined[1], "interaction"))
+        throw std::runtime_error(
+            "DNNModelEnergyMode must be total or interaction");
+    }
   }
   if(!found_name)  throw std::runtime_error("Model Name not found!!!!");
   if(!found_drift) throw std::runtime_error("Drift parameter not found!!!!");
 
   printf("DNN Model Name: %s\n", SystemComponents.ModelName[0].c_str());
+  printf(
+      "DNN Model Energy Mode: %s\n",
+      SystemComponents.DNN.ModelUsesTotalEnergy ? "total" : "interaction");
 }

--- a/patch.py
+++ b/patch.py
@@ -1,16 +1,5 @@
-import pathlib
-
-import matplotlib.pyplot as plt
-import numpy as np
-import pandas as pd
-import glob
 import os
-import os.path as path
-import re
 import shutil
-
-from itertools import repeat
-from typing import NamedTuple
 
 
 class patch:
@@ -61,9 +50,9 @@ def WritePatchTofile(fin, patch_list):
     
     shutil.move(temp, fin)
 
-#provide patch path here
-#it will read whatever after the '/' as the model name
-patch_path= ['cppflow-patch/LCLIN'] # Patch either 'libtorch-patch/Allegro' or 'cppflow-patch/LCLIN'
+# Select either 'libtorch-patch/Allegro' or 'cppflow-patch/LCLIN'.
+# The environment variable avoids editing this file for each build.
+patch_path = [os.environ.get("GRASPA_PATCH_PATH", "cppflow-patch/LCLIN")]
 clean_src = 'src_clean/'
 #patch_keyword = 'PATCH_LCLIN_SINGLE'
 for model in patch_path:

--- a/src_clean/dnn_energy_reference.h
+++ b/src_clean/dnn_energy_reference.h
@@ -1,0 +1,28 @@
+#pragma once
+
+#include <cstddef>
+
+inline double DNNHostGuestInteractionEnergy(
+    double combined_energy,
+    double host_energy,
+    double guest_energy)
+{
+  return combined_energy - host_energy - guest_energy;
+}
+
+template <typename Position>
+inline size_t CopySelectedDNNAtoms(
+    const Position* source,
+    Position* destination,
+    const bool* selected,
+    size_t source_size)
+{
+  size_t destination_index = 0;
+  for(size_t source_index = 0; source_index < source_size; source_index++)
+  {
+    if(!selected[source_index]) continue;
+    destination[destination_index] = source[source_index];
+    destination_index++;
+  }
+  return destination_index;
+}

--- a/src_clean/dnn_energy_reference.h
+++ b/src_clean/dnn_energy_reference.h
@@ -15,14 +15,22 @@ inline size_t CopySelectedDNNAtoms(
     const Position* source,
     Position* destination,
     const bool* selected,
-    size_t source_size)
+    size_t source_size,
+    size_t destination_capacity)
 {
+  size_t selected_count = 0;
+  for(size_t source_index = 0; source_index < source_size; source_index++)
+  {
+    if(selected[source_index]) selected_count++;
+  }
+
+  if(selected_count != destination_capacity) return selected_count;
+
   size_t destination_index = 0;
   for(size_t source_index = 0; source_index < source_size; source_index++)
   {
     if(!selected[source_index]) continue;
-    destination[destination_index] = source[source_index];
-    destination_index++;
+    destination[destination_index++] = source[source_index];
   }
-  return destination_index;
+  return selected_count;
 }

--- a/src_clean/torch_allegro.h
+++ b/src_clean/torch_allegro.h
@@ -595,27 +595,60 @@ struct Allegro
       size_t comp,
       double DNNEnergyConversion)
   {
-    const size_t HostUCSize = UCAtoms[0].size;
-    const size_t HostReplicaSize = ReplicaAtoms[0].size;
-    const size_t GuestUCSize = UCAtoms[comp].size;
-    const size_t GuestReplicaSize = ReplicaAtoms[comp].size;
+    struct AtomSizeRestoreGuard
+    {
+      Atoms& HostUC;
+      Atoms& HostReplica;
+      Atoms& GuestUC;
+      Atoms& GuestReplica;
+      const size_t HostUCSize;
+      const size_t HostReplicaSize;
+      const size_t GuestUCSize;
+      const size_t GuestReplicaSize;
+
+      AtomSizeRestoreGuard(
+          Atoms& host_uc,
+          Atoms& host_replica,
+          Atoms& guest_uc,
+          Atoms& guest_replica)
+          : HostUC(host_uc),
+            HostReplica(host_replica),
+            GuestUC(guest_uc),
+            GuestReplica(guest_replica),
+            HostUCSize(host_uc.size),
+            HostReplicaSize(host_replica.size),
+            GuestUCSize(guest_uc.size),
+            GuestReplicaSize(guest_replica.size)
+      {
+      }
+
+      ~AtomSizeRestoreGuard()
+      {
+        HostUC.size = HostUCSize;
+        HostReplica.size = HostReplicaSize;
+        GuestUC.size = GuestUCSize;
+        GuestReplica.size = GuestReplicaSize;
+      }
+    };
+
+    AtomSizeRestoreGuard RestoreSizes(
+        UCAtoms[0],
+        ReplicaAtoms[0],
+        UCAtoms[comp],
+        ReplicaAtoms[comp]);
 
     UCAtoms[comp].size = 0;
     ReplicaAtoms[comp].size = 0;
     HostReferenceEnergy =
         RawMCEnergyWrapper(comp, false, DNNEnergyConversion);
 
-    UCAtoms[comp].size = GuestUCSize;
-    ReplicaAtoms[comp].size = GuestReplicaSize;
+    UCAtoms[comp].size = RestoreSizes.GuestUCSize;
+    ReplicaAtoms[comp].size = RestoreSizes.GuestReplicaSize;
     UCAtoms[0].size = 0;
     ReplicaAtoms[0].size = 0;
     GuestReferenceEnergy =
         RawMCEnergyWrapper(comp, false, DNNEnergyConversion);
 
-    UCAtoms[0].size = HostUCSize;
-    ReplicaAtoms[0].size = HostReplicaSize;
-    UCAtoms[comp].size = GuestUCSize;
-    ReplicaAtoms[comp].size = GuestReplicaSize;
     ReferenceEnergyInitialized = true;
 
     printf(

--- a/src_clean/torch_allegro.h
+++ b/src_clean/torch_allegro.h
@@ -16,6 +16,10 @@ struct Allegro
   size_t DNN_Molsize = 0; //Atom size to be considered for DNN, since there might be fictional atom sites for a classical sim molecule
 
   size_t nstep = 0;
+  bool ModelUsesTotalEnergy = false;
+  bool ReferenceEnergyInitialized = false;
+  double HostReferenceEnergy = 0.0;
+  double GuestReferenceEnergy = 0.0;
 
   void Match_Element_PseudoAtom_with_model(PseudoAtomDefinitions& PseudoAtoms)
   {
@@ -210,7 +214,7 @@ struct Allegro
       UCAtoms[comp].pos[update_i]  = HostAtoms.pos[i];
       size_t SymbolIdx = Match_AllegroElement_PseudoAtom_order[HostAtoms.Type[i]];
       UCAtoms[comp].Type[update_i] = SymbolIdx;
-      if(i < 5 || i > (NAtoms - 5)) printf("Component %zu, Atom %zu, xyz %f %f %f, Type %zu, SymbolIndex %zu\n", comp, i, UCAtoms[comp].pos[i].x, UCAtoms[comp].pos[i].y, UCAtoms[comp].pos[i].z, HostAtoms.Type[i], UCAtoms[comp].Type[i]);
+      if(i < 5 || i > (NAtoms - 5)) printf("Component %zu, Atom %zu, xyz %f %f %f, Type %zu, SymbolIndex %zu\n", comp, i, UCAtoms[comp].pos[update_i].x, UCAtoms[comp].pos[update_i].y, UCAtoms[comp].pos[update_i].z, HostAtoms.Type[i], UCAtoms[comp].Type[update_i]);
       update_i ++;
     }
   }
@@ -572,8 +576,10 @@ struct Allegro
       */
     }
   }
-  //This function is called after the position of the trial adsorbate molecule is prepared in UCAtoms//
-  double MCEnergyWrapper(size_t comp, bool Initialize, double DNNEnergyConversion)
+  double RawMCEnergyWrapper(
+      size_t comp,
+      bool Initialize,
+      double DNNEnergyConversion)
   {
     WrapSuperCellAtomIntoUCBox(comp);
     GenerateReplicaCells(Initialize);
@@ -583,6 +589,59 @@ struct Allegro
     //This generates the unit of eV, convert to 10J/mol.
     //https://www.weizmann.ac.il/oc/martin/tools/hartree.html
     return DNN_E * DNNEnergyConversion;
+  }
+
+  void InitializeReferenceEnergies(
+      size_t comp,
+      double DNNEnergyConversion)
+  {
+    const size_t HostUCSize = UCAtoms[0].size;
+    const size_t HostReplicaSize = ReplicaAtoms[0].size;
+    const size_t GuestUCSize = UCAtoms[comp].size;
+    const size_t GuestReplicaSize = ReplicaAtoms[comp].size;
+
+    UCAtoms[comp].size = 0;
+    ReplicaAtoms[comp].size = 0;
+    HostReferenceEnergy =
+        RawMCEnergyWrapper(comp, false, DNNEnergyConversion);
+
+    UCAtoms[comp].size = GuestUCSize;
+    ReplicaAtoms[comp].size = GuestReplicaSize;
+    UCAtoms[0].size = 0;
+    ReplicaAtoms[0].size = 0;
+    GuestReferenceEnergy =
+        RawMCEnergyWrapper(comp, false, DNNEnergyConversion);
+
+    UCAtoms[0].size = HostUCSize;
+    ReplicaAtoms[0].size = HostReplicaSize;
+    UCAtoms[comp].size = GuestUCSize;
+    ReplicaAtoms[comp].size = GuestReplicaSize;
+    ReferenceEnergyInitialized = true;
+
+    printf(
+        "Allegro total-energy references: host %.10f, guest %.10f\n",
+        HostReferenceEnergy,
+        GuestReferenceEnergy);
+  }
+
+  //This function is called after the position of the trial adsorbate molecule is prepared in UCAtoms//
+  double MCEnergyWrapper(size_t comp, bool Initialize, double DNNEnergyConversion)
+  {
+    if(!ModelUsesTotalEnergy)
+      return RawMCEnergyWrapper(comp, Initialize, DNNEnergyConversion);
+
+    if(Initialize && !ReferenceEnergyInitialized)
+    {
+      RawMCEnergyWrapper(comp, true, DNNEnergyConversion);
+      InitializeReferenceEnergies(comp, DNNEnergyConversion);
+    }
+
+    double CombinedEnergy =
+        RawMCEnergyWrapper(comp, false, DNNEnergyConversion);
+    return DNNHostGuestInteractionEnergy(
+        CombinedEnergy,
+        HostReferenceEnergy,
+        GuestReferenceEnergy);
   }
   /*
   void CopyHostToUCAtoms(double3* pos, size_t comp, size_t Molsize)

--- a/src_clean/torch_allegro.h
+++ b/src_clean/torch_allegro.h
@@ -332,12 +332,11 @@ struct Allegro
 
     auto output = Model.forward(input_vector).toGenericDict();
 
-    torch::Tensor atomic_energy_tensor = output.at("atomic_energy").toTensor().cpu();
-    auto atomic_energies = atomic_energy_tensor.accessor<float, 2>();
+    torch::Tensor atomic_energy_tensor =
+        output.at("atomic_energy").toTensor().cpu().to(torch::kFloat64);
+    auto atomic_energies = atomic_energy_tensor.accessor<double, 2>();
 
-    float atomic_energy_sum = atomic_energy_tensor.sum().data_ptr<float>()[0];
-
-    float nAtomSum = 0.0;
+    double nAtomSum = 0.0;
     for(size_t i = 0; i < nAtoms; i++)
     {
       size_t AtomIndex = i;

--- a/tests/test_dnn_energy_reference.cpp
+++ b/tests/test_dnn_energy_reference.cpp
@@ -1,0 +1,28 @@
+#include "dnn_energy_reference.h"
+
+#include <cassert>
+#include <cmath>
+
+int main()
+{
+  const double combined = -1007.25;
+  const double host = -1000.0;
+  const double guest = -5.0;
+
+  const double interaction =
+      DNNHostGuestInteractionEnergy(combined, host, guest);
+
+  assert(std::abs(interaction - (-2.25)) < 1.0e-12);
+  assert(DNNHostGuestInteractionEnergy(3.0, 1.0, 2.0) == 0.0);
+
+  const int source[] = {10, 20, 30, 40};
+  const bool selected[] = {true, false, true, true};
+  int destination[] = {0, 0, 0};
+  const size_t copied =
+      CopySelectedDNNAtoms(source, destination, selected, 4);
+  assert(copied == 3);
+  assert(destination[0] == 10);
+  assert(destination[1] == 30);
+  assert(destination[2] == 40);
+  return 0;
+}

--- a/tests/test_dnn_energy_reference.cpp
+++ b/tests/test_dnn_energy_reference.cpp
@@ -19,10 +19,18 @@ int main()
   const bool selected[] = {true, false, true, true};
   int destination[] = {0, 0, 0};
   const size_t copied =
-      CopySelectedDNNAtoms(source, destination, selected, 4);
+      CopySelectedDNNAtoms(source, destination, selected, 4, 3);
   assert(copied == 3);
   assert(destination[0] == 10);
   assert(destination[1] == 30);
   assert(destination[2] == 40);
+
+  int guarded_destination[] = {-1, -1, 99};
+  const size_t overflow_count =
+      CopySelectedDNNAtoms(source, guarded_destination, selected, 4, 2);
+  assert(overflow_count == 3);
+  assert(guarded_destination[0] == -1);
+  assert(guarded_destination[1] == -1);
+  assert(guarded_destination[2] == 99);
   return 0;
 }


### PR DESCRIPTION
## Summary

This PR adds explicit support for Allegro models trained on **total
configuration energies**, while preserving the existing behavior for models
that directly predict **host–guest interaction energies**.

It introduces the optional `simulation.input` keyword:

```text
DNNModelEnergyMode total
```

The accepted values are:

| Mode | Intended model target | Energy passed to the Monte Carlo machinery |
|---|---|---|
| `interaction` | Host–guest interaction energy | The model prediction, unchanged |
| `total` | Total energy of the combined host–guest structure | `E(host + guest) - E(host) - E(guest)` |

If the keyword is omitted, gRASPA uses `interaction`, matching the behavior
before this change.

## Motivation

The existing Allegro integration assumes that the model output is already a
host–guest interaction energy. That assumption is not valid for Allegro
models trained on total energies.

For a rigid framework and rigid adsorbate, the energy needed by the current
Monte Carlo integration is

```text
E_interaction = E(host + guest) - E(host) - E(guest)
```

Passing `E(host + guest)` directly also includes the large, arbitrary energy
baselines of the framework and isolated molecule. Because insertion and
deletion acceptance probabilities contain a Boltzmann factor,
`exp(-beta * DeltaU)`, even a modest unwanted constant can change acceptance
by many orders of magnitude. Framework-scale offsets can therefore produce
unphysical acceptance probabilities, including effectively zero insertion
acceptance (or, for an offset of the opposite sign, near-unconditional
acceptance).

## Implementation

When `DNNModelEnergyMode total` is selected, gRASPA now:

1. evaluates the empty rigid framework once during Allegro initialization;
2. evaluates the isolated rigid adsorbate once during initialization;
3. stores both reference energies; and
4. subtracts them from every combined host–guest prediction.

The selected mode and, in `total` mode, the computed reference energies are
printed at startup to make the energy convention visible in simulation logs.
Invalid values for `DNNModelEnergyMode` are rejected with an explanatory
error.

The reference-energy arithmetic and selected-atom copying logic are kept in a
small standalone header so that they can be tested without linking LibTorch.

## Selected DNN atom handling

This PR also fixes the copy operation used when only a subset of adsorbate
sites is included in the Allegro model—for example, when a classical molecule
definition contains a virtual site that is absent from the ML model.

Previously, the destination index advanced for every molecular site,
including excluded sites. This could leave gaps or write selected atoms to
incorrect positions. The destination index now advances only when an atom is
selected, and gRASPA verifies that the number of copied atoms matches the
allocated Allegro input size.

## Scope and assumptions

The cached reference energies are appropriate for the existing rigid-framework,
rigid-adsorbate GCMC path. They assume that the reference framework and
intramolecular adsorbate geometries do not change during the initialized
gRASPA run.

If a future in-process coupling allows the framework or molecular reference
geometry to change, the corresponding reference energy must be recomputed or
invalidated. Workflows that alternate separate fixed-framework gRASPA runs
with external MD stages naturally recompute the references when each new
gRASPA process starts.

This change does not expand the component or flexibility scope of the existing
Allegro integration; it corrects the interpretation of model energies within
that scope.

## Backward compatibility

- `DNNModelEnergyMode interaction` retains the previous behavior.
- Omitting `DNNModelEnergyMode` is equivalent to `interaction`.
- The existing `CO2_MgMOF74_Allegro` example therefore behaves as before.
- No model retraining or conversion is required.

The example README now documents when `total` mode should be used.

## Patch-generation cleanup

The Allegro patch templates were updated alongside the clean source.
`patch.py` now:

- removes unused Python dependencies;
- accepts `GRASPA_PATCH_PATH` so the patch target can be selected without
  editing the script; and
- keeps generated `patch_*` source trees out of version control.

## Validation

- Added `tests/test_dnn_energy_reference.cpp`.
- Verified subtraction of host and guest reference energies.
- Verified compact copying of a selected atom subset.
- Compiled and ran the standalone test successfully with:

  ```text
  g++ -std=c++17 -Isrc_clean tests/test_dnn_energy_reference.cpp
  ```

## Example input

For a model trained on total configuration energies:

```text
UseAllegro yes
DNNModelEnergyMode total
```

For a model trained directly on host–guest interaction energies, omit the
keyword or use:

```text
DNNModelEnergyMode interaction
```


## Allegro output dtype compatibility

Some exported Allegro TorchScript models return the `atomic_energy` tensor
as float64. The previous integration unconditionally requested a float32
tensor accessor, which makes LibTorch abort at runtime with:

```text
expected scalar type Float but found Double
```

The returned atomic-energy tensor is now moved to the CPU and converted to
float64 before it is accessed, and the selected atomic energies are
accumulated in a C++ `double`. Float32 model outputs are promoted without
losing information, while float64 outputs retain their precision. Double
precision is also important in `total` mode because the host and guest
reference energies can be large and their subtraction is sensitive to
roundoff.

A CPU-only regression test checks that the Allegro output path uses the
float64 accessor and accumulation. The updated ROCm build was additionally
validated in a short UiO-66/H2O GCMC smoke run on LUMI: gRASPA recognized one
framework and one adsorbate, loaded the float64 model, printed the total-energy
references, attempted insertion moves, wrote movie snapshots, and reached
`END OF PROGRAM`.
